### PR TITLE
Save Web Server URL on Login and Added User Confirmation Dialog When Logging off

### DIFF
--- a/app/src/main/java/org/dhis2/mobile/ui/activities/ConfirmUserActivity.java
+++ b/app/src/main/java/org/dhis2/mobile/ui/activities/ConfirmUserActivity.java
@@ -28,8 +28,10 @@
 
 package org.dhis2.mobile.ui.activities;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.view.animation.Animation;
@@ -115,10 +117,21 @@ public class ConfirmUserActivity extends BaseActivity {
 
     @OnClick(R.id.delete_and_log_out_button)
     public void deleteAndLogOut() {
-        showProgress(true);
-        getDhisService().logOutUser();
-        startActivity(new Intent(this, LauncherActivity.class));
-        finish();
+
+        new AlertDialog.Builder(ConfirmUserActivity.this)
+                .setMessage(R.string.delete_and_log_out_question)
+                .setCancelable(false)
+                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        showProgress(true);
+                        getDhisService().logOutUser();
+                        startActivity(new Intent(ConfirmUserActivity.this, LauncherActivity.class));
+                        finish();
+                    }
+                })
+                .setNegativeButton("No", null)
+                .show();
+
     }
 
     @Subscribe

--- a/app/src/main/java/org/dhis2/mobile/ui/activities/LoginActivity.java
+++ b/app/src/main/java/org/dhis2/mobile/ui/activities/LoginActivity.java
@@ -36,6 +36,7 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 
 import com.squareup.otto.Subscribe;
 
@@ -43,6 +44,7 @@ import org.dhis2.mobile.R;
 import org.dhis2.mobile.sdk.entities.UserAccount;
 import org.dhis2.mobile.sdk.network.APIException;
 import org.dhis2.mobile.sdk.network.models.Credentials;
+import org.dhis2.mobile.utils.PreferenceUtil;
 
 import butterknife.ButterKnife;
 import butterknife.InjectView;
@@ -61,6 +63,7 @@ public class LoginActivity extends BaseActivity {
     @InjectView(R.id.username) EditText mUsername;
     @InjectView(R.id.password) EditText mPassword;
     @InjectView(R.id.log_in_button) Button mLogInButton;
+    @InjectView(R.id.url) TextView mUrl;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -68,7 +71,11 @@ public class LoginActivity extends BaseActivity {
         setContentView(R.layout.activity_login);
         ButterKnife.inject(this);
 
-        mServerUrl.setText("https://apps.dhis2.org/demo/");
+        String currentServerUrl = PreferenceUtil.getServerUrl(LoginActivity.this);
+        mServerUrl.setText(currentServerUrl);
+        mServerUrl.setVisibility(View.GONE);
+
+        mUrl.setText(currentServerUrl);
         mUsername.setText("admin");
         mPassword.setText("district");
 
@@ -102,6 +109,13 @@ public class LoginActivity extends BaseActivity {
         );
     }
 
+    @OnClick(R.id.url)
+    public void hideUrl() {
+        mUrl.setVisibility(View.GONE);
+        mServerUrl.setVisibility(View.VISIBLE);
+    }
+
+
     @OnClick(R.id.log_in_button)
     public void logIn() {
         showProgress(true);
@@ -111,6 +125,11 @@ public class LoginActivity extends BaseActivity {
         String password = mPassword.getText().toString();
 
         if (serverUrl != null) {
+            PreferenceUtil.savePrefs(PreferenceUtil.SERVER_URL,serverUrl,LoginActivity.this);
+            mUrl.setVisibility(View.VISIBLE);
+            mServerUrl.setVisibility(View.GONE);
+            mUrl.setText(serverUrl);
+
             Uri serverUri = Uri.parse(serverUrl);
             getDhisService().logInUser(
                     serverUri, new Credentials(username, password)

--- a/app/src/main/java/org/dhis2/mobile/ui/activities/MenuActivity.java
+++ b/app/src/main/java/org/dhis2/mobile/ui/activities/MenuActivity.java
@@ -28,6 +28,7 @@
 
 package org.dhis2.mobile.ui.activities;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
@@ -36,6 +37,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
@@ -74,9 +76,13 @@ public class MenuActivity extends BaseActivity {
     private static final int SETTINGS_MENU_ITEM = 401;
     private static final int ABOUT_MENU_ITEM = 402;
 
-    @InjectView(R.id.toolbar) Toolbar mToolbar;
-    @InjectView(R.id.drawer_layout) @Optional DrawerLayout mDrawerLayout;
-    @InjectView(R.id.left_drawer) ListView mNavigationListView;
+    @InjectView(R.id.toolbar)
+    Toolbar mToolbar;
+    @InjectView(R.id.drawer_layout)
+    @Optional
+    DrawerLayout mDrawerLayout;
+    @InjectView(R.id.left_drawer)
+    ListView mNavigationListView;
 
     ActionBarDrawerToggle mDrawerToggle;
     Runnable mPendingRunnable;
@@ -134,9 +140,19 @@ public class MenuActivity extends BaseActivity {
         final Fragment fragment = findFragmentById(id);
 
         if (id == LOG_OUT_MENU_ITEM) {
-            getDhisService().logOutUser();
-            startActivity(new Intent(this, LauncherActivity.class));
-            finish();
+            new AlertDialog.Builder(MenuActivity.this)
+                    .setMessage(R.string.log_out_question)
+                    .setCancelable(false)
+                    .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            getDhisService().logOutUser();
+                            startActivity(new Intent(MenuActivity.this, LauncherActivity.class));
+                            finish();
+                        }
+                    })
+                    .setNegativeButton("No", null)
+                    .show();
+            return;
         }
 
         if (id == ABOUT_MENU_ITEM) {

--- a/app/src/main/java/org/dhis2/mobile/utils/PreferenceUtil.java
+++ b/app/src/main/java/org/dhis2/mobile/utils/PreferenceUtil.java
@@ -1,0 +1,32 @@
+package org.dhis2.mobile.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+/**
+ * Created by tdhlakama on 2/11/2016.
+ */
+public class PreferenceUtil {
+
+    public static String SERVER_URL = "SERVER_URL";
+
+    public static String getServerUrl(Context context) {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        return sp.getString(SERVER_URL, "https://play.dhis2.org/demo/");
+    }
+
+    public static void removePrefs(String key, Context context) {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.remove(key);
+        editor.commit();
+    }
+
+    public static void savePrefs(String key, String value, Context context) {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sp.edit();
+        editor.putString(key, value);
+        editor.commit();
+    }
+}

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -83,6 +83,21 @@
             android:singleLine="true"
             app:font="@string/regular_font_name"/>
 
+        <TextView
+            android:id="@+id/url"
+            android:layout_width="match_parent"
+            android:layout_height="42dp"
+            android:layout_marginBottom="1px"
+            android:layout_marginLeft="4dp"
+            android:layout_marginRight="4dp"
+            android:background="@drawable/edittext_custom_shape"
+            android:drawableLeft="@mipmap/ic_server"
+            android:drawablePadding="8dp"
+            android:gravity="center_vertical"
+            android:hint="@string/server_url"
+            android:paddingLeft="6dp"
+            android:singleLine="true" />
+
         <org.dhis2.mobile.ui.views.FontEditText
             android:id="@+id/username"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <!-- START ConfirmUserActivity resources -->
     <string name="delete_and_log_out">Delete and log out</string>
     <string name="re_log_in">Re-Log In</string>
+    <string name="delete_and_log_out_question">Are you sure you want delete user data?</string>
     <!-- END -->
 
     <!-- START MenuActivity resources -->
@@ -37,6 +38,7 @@
     <string name="log_out">Log out</string>
     <string name="other">OTHER</string>
     <string name="about">About</string>
+    <string name="log_out_question">Are you sure you want to log out?</string>
     <!-- END -->
 
     <!-- START Toast Messages -->


### PR DESCRIPTION
Save web server URL in Preferences to prevent a user from retyping the server name every time they want to login. Login Activity will display a text view with last saved server URL. if user wants to change that server they simply click the text view and it will change to a edit text where you can type in the new server URL. The code will maintain the same style of presentation currently implemented in the Login Activity.

Added Confirmation Dialog when user wants to log off. Worked on issue marked as enhancement #16 opened 24 days ago by ArazAbishov  
